### PR TITLE
admin use only fix

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,5 +21,13 @@ require_once BLACKBOX_DIR.'/application/BlackBox/Exception.php';
 require_once BLACKBOX_DIR.'/application/BlackBox/WPConstants.php';
 require_once BLACKBOX_DIR.'/application/BlackBox/WPGlobals.php';
 
-if ( is_admin() )
-	BlackBox::init();
+BlackBox::init();
+
+// remove the blackbox display if not administrator role
+add_action('plugins_loaded','blackbox_user_filter');
+function blackbox_user_filter() {
+	global $current_user; $current_user = wp_get_current_user();
+	if (in_array('administrator', $current_user->roles)) {return;}
+	remove_action('admin_footer', array('BlackBox_Hook', 'footer'));
+	remove_action('wp_footer', array('BlackBox_Hook', 'footer'));
+}


### PR DESCRIPTION
Blackbox needs to be able to debug on the front-end, but only show for developers (ie. administrator role.)
Using is_admin() (a change from the original Blackbox) prevented this version from any front-end use at all.
This is a hacky fix after the fact, but it works. It could be better implemented in the Blackbox class.
And possibly provide a filter for allowed roles and/or capabilities so the plugin only loads when it is needed.
